### PR TITLE
Reduce VRAM requirement to 1GB and add one-click installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ LTX Desktop is an open-source desktop app for generating videos with LTX models 
 
 | Platform / hardware | Generation mode | Notes |
 | --- | --- | --- |
-| Windows + CUDA GPU with **≥32GB VRAM** | Local generation | Downloads model weights locally |
-| Windows (no CUDA, <32GB VRAM, or unknown VRAM) | API-only | **LTX API key required** |
+| Windows + CUDA GPU with **≥1GB VRAM** | Local generation | Downloads model weights locally |
+| Windows (no CUDA or unknown VRAM) | API-only | **LTX API key required** |
 | macOS (Apple Silicon builds) | API-only | **LTX API key required** |
 | Linux | Not officially supported | No official builds |
 
@@ -42,7 +42,7 @@ In API-only mode, available resolutions/durations may be limited to what the API
 ### Windows (local generation)
 
 - Windows 10/11 (x64)
-- NVIDIA GPU with CUDA support and **≥32GB VRAM** (more is better)
+- NVIDIA GPU with CUDA support and **≥1GB VRAM** (more is better)
 - 16GB+ RAM (32GB recommended)
 - Plenty of free disk space for model weights and outputs
 

--- a/backend/runtime_config/runtime_policy.py
+++ b/backend/runtime_config/runtime_policy.py
@@ -13,7 +13,7 @@ def decide_force_api_generations(system: str, cuda_available: bool, vram_gb: int
             return True
         if vram_gb is None:
             return True
-        return vram_gb < 31
+        return vram_gb < 1
 
     # Fail closed for non-target platforms unless explicitly relaxed.
     return True

--- a/backend/tests/test_runtime_policy_decision.py
+++ b/backend/tests/test_runtime_policy_decision.py
@@ -15,7 +15,7 @@ def test_windows_without_cuda_forces_api() -> None:
 
 
 def test_windows_with_low_vram_forces_api() -> None:
-    assert decide_force_api_generations(system="Windows", cuda_available=True, vram_gb=30) is True
+    assert decide_force_api_generations(system="Windows", cuda_available=True, vram_gb=0) is True
 
 
 def test_windows_with_unknown_vram_forces_api() -> None:
@@ -23,7 +23,7 @@ def test_windows_with_unknown_vram_forces_api() -> None:
 
 
 def test_windows_with_required_vram_allows_local_mode() -> None:
-    assert decide_force_api_generations(system="Windows", cuda_available=True, vram_gb=31) is False
+    assert decide_force_api_generations(system="Windows", cuda_available=True, vram_gb=1) is False
 
 
 def test_other_systems_fail_closed() -> None:

--- a/build-installer.bat
+++ b/build-installer.bat
@@ -1,0 +1,114 @@
+@echo off
+setlocal EnableDelayedExpansion
+
+echo.
+echo   _   _______  __  ____            _    _
+echo  ^| ^| ^|_   _\ \/ / ^|  _ \  ___  ___^| ^| _^| ^|_ ___  _ __
+echo  ^| ^|   ^| ^|  \  /  ^| ^| ^| ^|/ _ \/ __^| ^|/ / __/ _ \^| '_ \
+echo  ^| ^|___^| ^|  /  \  ^| ^|_^| ^|  __/\__ \   ^<^| ^|^| (_) ^| ^|_) ^|
+echo  ^|_____^|_^| /_/\_\ ^|____/ \___^|^|___/_^|\_\\__\___/^| .__/
+echo                                                  ^|_^|
+echo   One-Click Installer Build
+echo.
+
+:: ============================================================
+:: Check prerequisites
+:: ============================================================
+
+echo Checking prerequisites...
+echo.
+
+where node >nul 2>&1
+if %ERRORLEVEL% neq 0 (
+    echo [ERROR] Node.js not found.
+    echo         Download and install from: https://nodejs.org/
+    echo.
+    goto :fail
+)
+for /f "tokens=*" %%v in ('node -v') do echo [OK] Node.js %%v
+
+where git >nul 2>&1
+if %ERRORLEVEL% neq 0 (
+    echo [ERROR] Git not found.
+    echo         Download and install from: https://git-scm.com/
+    echo.
+    goto :fail
+)
+for /f "tokens=*" %%v in ('git --version') do echo [OK] %%v
+
+:: ============================================================
+:: Install pnpm if missing
+:: ============================================================
+
+where pnpm >nul 2>&1
+if %ERRORLEVEL% neq 0 (
+    echo.
+    echo Installing pnpm...
+    call npm install -g pnpm
+    if !ERRORLEVEL! neq 0 (
+        echo [ERROR] Failed to install pnpm.
+        goto :fail
+    )
+)
+for /f "tokens=*" %%v in ('pnpm --version') do echo [OK] pnpm %%v
+
+:: ============================================================
+:: Install uv if missing
+:: ============================================================
+
+where uv >nul 2>&1
+if %ERRORLEVEL% neq 0 (
+    echo.
+    echo Installing uv (Python package manager)...
+    powershell -ExecutionPolicy ByPass -Command "irm https://astral.sh/uv/install.ps1 | iex"
+    if !ERRORLEVEL! neq 0 (
+        echo [ERROR] Failed to install uv.
+        goto :fail
+    )
+    :: Refresh PATH so uv is available
+    for /f "tokens=*" %%p in ('powershell -Command "[Environment]::GetEnvironmentVariable('Path','User')"') do set "PATH=%%p;%PATH%"
+)
+for /f "tokens=*" %%v in ('uv --version') do echo [OK] %%v
+
+echo.
+echo All prerequisites satisfied.
+echo.
+
+:: ============================================================
+:: Run the full build
+:: ============================================================
+
+echo Starting full installer build...
+echo This will download ~10GB of dependencies and may take a while.
+echo.
+
+powershell -ExecutionPolicy ByPass -File "%~dp0scripts\local-build.ps1"
+if %ERRORLEVEL% neq 0 (
+    echo.
+    echo [ERROR] Build failed. Check the output above for details.
+    goto :fail
+)
+
+:: ============================================================
+:: Success
+:: ============================================================
+
+echo.
+echo =========================================================
+echo   BUILD COMPLETE!
+echo   Your installer is in the release\ folder.
+echo =========================================================
+echo.
+
+if exist "%~dp0release" (
+    explorer "%~dp0release"
+)
+
+pause
+exit /b 0
+
+:fail
+echo.
+echo Build failed. Please fix the errors above and try again.
+pause
+exit /b 1


### PR DESCRIPTION
Lower the minimum VRAM threshold from 31GB to 1GB so local generation is available on GPUs with less VRAM. Add build-installer.bat for one-click Windows installer builds.

https://claude.ai/code/session_01VcNJKbUrfrx4yEGxJVFkFE