### PR TITLE
set outputs dir to be under app data

### DIFF
--- a/backend/ltx2_server.py
+++ b/backend/ltx2_server.py
@@ -153,7 +153,7 @@ MODELS_DIR = APP_DATA_DIR / "models"
 MODELS_DIR.mkdir(parents=True, exist_ok=True)
 
 PROJECT_ROOT = Path(__file__).parent.parent
-OUTPUTS_DIR = Path(__file__).parent / "outputs"
+OUTPUTS_DIR = APP_DATA_DIR / "outputs"
 OUTPUTS_DIR.mkdir(parents=True, exist_ok=True)
 
 logger.info(f"Models directory: {MODELS_DIR}")


### PR DESCRIPTION
the current one (backend/outputs) is a poor choice and doesn't work when the app's installation is readonly.