### PR TITLE
Set PYTHONNOUSERSITE=1 to isolate bundled Python

### DIFF
--- a/electron/python-backend.ts
+++ b/electron/python-backend.ts
@@ -221,6 +221,7 @@ export async function startPythonBackend(): Promise<void> {
       env: {
         ...process.env,
         PYTHONUNBUFFERED: '1',
+        PYTHONNOUSERSITE: '1',
         LTX_PORT: String(PYTHON_PORT),
         LTX_APP_DATA_DIR: getAppDataDir(),
         PYTORCH_ENABLE_MPS_FALLBACK: '1',


### PR DESCRIPTION
## Summary
- Set `PYTHONNOUSERSITE=1` when spawning the backend process, preventing system-wide Python packages from leaking into the bundled runtime
- Fixes crashes caused by conflicting packages (e.g. `torchvision`) from a user's separate Python 3.13 installation

Fixes part of https://github.com/Lightricks/LTX-Desktop/issues/7

## Test plan
- [x] TypeScript typecheck passes
- [ ] Verify on Windows with system Python 3.13 + torchvision installed that the backend starts cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)