### PR TITLE
Fix setup-dev.ps1 failing on Windows PowerShell 5.1

### DIFF
--- a/scripts/setup-dev.ps1
+++ b/scripts/setup-dev.ps1
@@ -2,15 +2,15 @@
 
 $ErrorActionPreference = "Stop"
 
-function Ok($msg)   { Write-Host "✓ $msg" -ForegroundColor Green }
-function Fail($msg) { Write-Host "✗ $msg" -ForegroundColor Red; exit 1 }
+function Ok($msg)   { Write-Host "[OK] $msg" -ForegroundColor Green }
+function Fail($msg) { Write-Host "[FAIL] $msg" -ForegroundColor Red; exit 1 }
 
-# ── Pre-checks ──────────────────────────────────────────────────────
+# -- Pre-checks ------------------------------------------------------
 if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
-    Fail "node not found — install Node.js 18+ from https://nodejs.org/"
+    Fail "node not found - install Node.js 18+ from https://nodejs.org/"
 }
 if (-not (Get-Command uv -ErrorAction SilentlyContinue)) {
-    Fail "uv not found — install with: powershell -ExecutionPolicy ByPass -c 'irm https://astral.sh/uv/install.ps1 | iex'"
+    Fail "uv not found - install with: powershell -ExecutionPolicy ByPass -c 'irm https://astral.sh/uv/install.ps1 | iex'"
 }
 Ok "node $(node -v)"
 Ok "uv   $(uv --version)"
@@ -18,14 +18,14 @@ Ok "uv   $(uv --version)"
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $ProjectDir = Split-Path -Parent $ScriptDir
 
-# ── npm install ─────────────────────────────────────────────────────
+# -- npm install -----------------------------------------------------
 Write-Host "`nInstalling Node dependencies..."
 Set-Location $ProjectDir
 npm install
 if ($LASTEXITCODE -ne 0) { Fail "npm install failed" }
 Ok "npm install complete"
 
-# ── uv sync ─────────────────────────────────────────────────────────
+# -- uv sync ---------------------------------------------------------
 Write-Host "`nSetting up Python backend venv..."
 Set-Location (Join-Path $ProjectDir "backend")
 uv sync --extra dev
@@ -37,21 +37,21 @@ Write-Host "`nVerifying PyTorch CUDA support..."
 try {
     & .venv\Scripts\python.exe -c "import torch; cuda=torch.cuda.is_available(); print(f'CUDA available: {cuda}'); print(f'GPU: {torch.cuda.get_device_name(0)}') if cuda else None"
 } catch {
-    Write-Host "  Could not verify PyTorch — this is OK if setup is still downloading." -ForegroundColor DarkYellow
+    Write-Host "  Could not verify PyTorch - this is OK if setup is still downloading." -ForegroundColor DarkYellow
 }
 
-# ── ffmpeg check ────────────────────────────────────────────────────
+# -- ffmpeg check ----------------------------------------------------
 Write-Host ""
 if (Get-Command ffmpeg -ErrorAction SilentlyContinue) {
     $ffmpegVer = (ffmpeg -version 2>&1 | Select-Object -First 1)
     Ok "ffmpeg found: $ffmpegVer"
 } else {
-    Write-Host "⚠  ffmpeg not found — install with: winget install ffmpeg" -ForegroundColor Yellow
+    Write-Host "[WARN] ffmpeg not found -- install with: winget install ffmpeg" -ForegroundColor Yellow
     Write-Host "   (imageio-ffmpeg bundled binary will be used as fallback)" -ForegroundColor Yellow
 }
 
 Write-Host ""
-Write-Host "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━" -ForegroundColor Cyan
+Write-Host "---------------------------------------------------------" -ForegroundColor Cyan
 Write-Host "  Setup complete! Run the app with:  npm run dev" -ForegroundColor Cyan
 Write-Host "  Debug mode (with debugpy):         npm run dev:debug" -ForegroundColor Cyan
-Write-Host "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━" -ForegroundColor Cyan
+Write-Host "---------------------------------------------------------" -ForegroundColor Cyan


### PR DESCRIPTION
Windows PowerShell 5.1 reads UTF-8 files without a BOM using the system ANSI code page (CP1252). Several Unicode characters in the script (em-dashes, box-drawing chars, checkmarks) contain bytes that are interpreted as string delimiters in CP1252, causing a parser error. This PR replaces all non-ASCII characters with ASCII equivalents for ease of compatibility long term

<img width="794" height="240" alt="image" src="https://github.com/user-attachments/assets/e44dba19-75a5-4349-8648-632e638aa23c" />
