### PR TITLE
fix Bug : lose generation result if leave gen space

### DIFF
--- a/frontend/views/Project.tsx
+++ b/frontend/views/Project.tsx
@@ -152,9 +152,10 @@ export function Project() {
       </header>
       
       <main className="flex-1 overflow-hidden relative">
-        {currentTab === 'gen-space' ? (
+        <div className={currentTab === 'gen-space' ? 'h-full' : 'hidden h-full'}>
           <GenSpace />
-        ) : (
+        </div>
+        <div className={currentTab === 'video-editor' ? 'h-full' : 'hidden h-full'}>
           <VideoEditor
             key={currentProject.id}
             currentProject={currentProject}
@@ -162,7 +163,7 @@ export function Project() {
             pendingRetakeUpdate={pendingRetakeUpdate}
             pendingIcLoraUpdate={pendingIcLoraUpdate}
           />
-        )}
+        </div>
       </main>
     </div>
   )


### PR DESCRIPTION
Replace conditional rendering with class-based visibility for the 'GenSpace' and 'VideoEditor' components, This fix the bug of losing the generation if swapped taps while something is generating


https://github.com/Lightricks/LTX-Desktop/issues/85


Fixed. GenSpace no longer unmounts when you switch to Video Editor, so in-progress generation state remains alive and visible when you come back.

What changed:

Updated Project.tsx to keep both tab components mounted and toggle visibility with hidden instead of conditional mount/unmount.
Why this fixes it:

Before: tab switch destroyed GenSpace state (useGeneration state, progress UI, completion handlers).
Now: GenSpace stays mounted, so generation progress/result handling continues even while you’re on editor tab.