### PR TITLE
Fix silent loss of completed Extend results

### DIFF
--- a/frontend/contexts/ProjectContext.tsx
+++ b/frontend/contexts/ProjectContext.tsx
@@ -179,11 +179,14 @@ export function ProjectProvider({ children }: { children: React.ReactNode }) {
       createdAt: Date.now(),
     }
 
-    mutateProject(projectId, project => ({
+    const persistedProject = mutateProject(projectId, project => ({
       ...project,
       assets: [newAsset, ...project.assets],
       updatedAt: Date.now(),
     }))
+    if (!persistedProject) {
+      throw new Error(`Cannot add asset: project ${projectId} was not found`)
+    }
 
     return newAsset
   }, [mutateProject])

--- a/frontend/views/GenSpace.tsx
+++ b/frontend/views/GenSpace.tsx
@@ -1446,6 +1446,7 @@ export function GenSpace() {
     prompt: string
     input: { videoPath: string; direction: ExtendDirection; duration: number; videoDuration: number }
   } | null>(null)
+  const persistingExtendResultRef = useRef<string | null>(null)
   const [retakeInitial, setRetakeInitial] = useState<{
     videoPath: string | null
     duration?: number
@@ -1850,60 +1851,69 @@ export function GenSpace() {
     })()
   }, [retakeResult, isRetaking, currentProjectId, activeProject?.assets, activeRetakeSource, addAsset, addTakeToAsset, setPendingRetakeUpdate, resetRetake])
 
-  // When extend completes, save the longer video as a new asset.
+  // When extend completes, save the longer video as a new asset. Keep the recovery marker until
+  // the project write succeeds: copying/thumbnails can finish before a later storage error, and
+  // dropping the marker earlier would leave a valid output stranded with no retry path.
   useEffect(() => {
     if (!extendResult || !currentProjectId || isExtending) return
     const submission = extendSubmissionRef.current
     if (!submission) return
-    extendSubmissionRef.current = null
-    localStorage.removeItem(GENERATION_RECOVERY_KEY)
+    const generationKey = extendResult.videoPath
+    if (persistingExtendResultRef.current === generationKey) return
+    persistingExtendResultRef.current = generationKey
 
     ;(async () => {
-      const usedPrompt = submission.prompt
-      const usedInput = submission.input
-      const copied = await addVisualAssetToProject(extendResult.videoPath, currentProjectId, 'video')
-      if (!copied) {
-        logger.error('Could not persist extend result to project storage')
-        setLocalError(createLocalGenerationError('Failed to save extend output to project storage.'))
-        resetExtend()
-        return
-      }
+      try {
+        const usedPrompt = submission.prompt
+        const usedInput = submission.input
+        const copied = await addVisualAssetToProject(extendResult.videoPath, currentProjectId, 'video')
+        if (!copied) throw new Error('Could not persist extend result to project storage')
 
-      addAsset(currentProjectId, {
-        type: 'video',
-        path: copied.path,
-        bigThumbnailPath: copied.bigThumbnailPath,
-        smallThumbnailPath: copied.smallThumbnailPath,
-        width: copied.width,
-        height: copied.height,
-        prompt: usedPrompt,
-        resolution: '',
-        duration: usedInput.videoDuration + usedInput.duration,
-        generationParams: {
-          mode: 'extend',
-          prompt: usedPrompt,
-          model: 'pro',
-          duration: usedInput.videoDuration + usedInput.duration,
-          resolution: '',
-          fps: 24,
-          audio: true,
-          cameraMotion: 'none',
-          extendVideoPath: copied.path,
-          extendDuration: usedInput.duration,
-          extendDirection: usedInput.direction,
-        },
-        takes: [{
+        addAsset(currentProjectId, {
+          type: 'video',
           path: copied.path,
           bigThumbnailPath: copied.bigThumbnailPath,
           smallThumbnailPath: copied.smallThumbnailPath,
           width: copied.width,
           height: copied.height,
-          createdAt: Date.now(),
-        }],
-        activeTakeIndex: 0,
-      })
-      setMode('video')
-      resetExtend()
+          prompt: usedPrompt,
+          resolution: '',
+          duration: usedInput.videoDuration + usedInput.duration,
+          generationParams: {
+            mode: 'extend',
+            prompt: usedPrompt,
+            model: 'pro',
+            duration: usedInput.videoDuration + usedInput.duration,
+            resolution: '',
+            fps: 24,
+            audio: true,
+            cameraMotion: 'none',
+            extendVideoPath: copied.path,
+            extendDuration: usedInput.duration,
+            extendDirection: usedInput.direction,
+          },
+          takes: [{
+            path: copied.path,
+            bigThumbnailPath: copied.bigThumbnailPath,
+            smallThumbnailPath: copied.smallThumbnailPath,
+            width: copied.width,
+            height: copied.height,
+            createdAt: Date.now(),
+          }],
+          activeTakeIndex: 0,
+        })
+
+        extendSubmissionRef.current = null
+        persistingExtendResultRef.current = null
+        localStorage.removeItem(GENERATION_RECOVERY_KEY)
+        setMode('video')
+        resetExtend()
+      } catch (error) {
+        persistingExtendResultRef.current = null
+        logger.error(`Failed to persist extend result: ${error}`)
+        setLocalError(createLocalGenerationError('Failed to save extend output to project storage. The app will retry automatically.'))
+        resetExtend()
+      }
     })()
   }, [extendResult, isExtending, currentProjectId, addAsset, resetExtend])
 


### PR DESCRIPTION
## Summary

- make completed Extend result persistence transactional
- retain the generation recovery marker until the project asset write succeeds
- surface persistence failures to the user while preserving the automatic retry path
- fail explicitly when `addAsset` targets a project that no longer exists

## Bug report

Extending a local video could finish successfully in the backend but produce no visible result and no failure notice in the UI.

The captured session showed:

1. the Extend generation completed successfully
2. the backend saved the output MP4
3. Electron copied the MP4 into the project asset directory
4. Electron generated both thumbnails
5. no asset appeared in the project and no error was shown

Expected behavior: the completed video appears as a generated Extend asset. If the project write fails, the user receives an error and the completed generation remains recoverable.

## Root cause

The Extend completion effect cleared its submission context and removed `ltx-generation-recovery` before awaiting the asset copy and project write. The asynchronous import also had no catch boundary.

That left a silent-loss window: a project storage failure after the video and thumbnails were created could strand a valid result while also removing the only recovery path. In addition, `ProjectContext.addAsset` returned a new asset even when `mutateProject` returned `null`, so a missing project looked like a successful write.

## Fix

- deduplicate in-flight persistence for a completed Extend result
- wrap the full copy/write sequence in error handling
- clear the submission context and recovery marker only after `addAsset` succeeds
- keep the recovery marker on failure so the background watcher can retry
- show a generation failure instead of silently dropping the result
- throw from `addAsset` when the target project cannot be loaded

## Validation

- `pnpm typecheck`
- `pnpm build:frontend`
- `pnpm backend:test` — 567 passed
- manual Electron success path using a deterministic Extend response and the real file-copy/thumbnail IPC:
  - Extend asset added with the expected generation metadata and duration
  - recovery marker removed after the project write
- manual storage-failure injection:
  - precise persistence error logged
  - visible failure dialog shown
  - recovery marker retained for retry

The manual regression fixture and copied media were removed after validation.
