### PR TITLE
Clarify Pro model availability in local mode

### DIFF
--- a/frontend/components/SettingsModal.tsx
+++ b/frontend/components/SettingsModal.tsx
@@ -433,10 +433,10 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
                       <div className="flex-1">
                         <div className="flex items-center gap-2">
                           <Zap className="h-4 w-4 text-blue-400" />
-                          <span className="text-sm font-medium text-white">Generate With API</span>
+                          <span className="text-sm font-medium text-white">Use LTX API Models</span>
                         </div>
                         <p className="text-xs text-zinc-400 mt-1">
-                          Use LTX API for video generation when an LTX API key is configured.
+                          Unlocks LTX-2.3 Fast and Pro in the model selector. Local generation supports Fast only.
                         </p>
                       </div>
                       <div className={`w-5 h-5 rounded-full border-2 flex items-center justify-center ${

--- a/frontend/views/GenSpace.tsx
+++ b/frontend/views/GenSpace.tsx
@@ -914,10 +914,22 @@ function PromptBar({
                   title="MODEL"
                   value={resolvedVideoOptions.selectedModel ?? settings.model}
                   onChange={(v) => onSettingsChange({ ...settings, model: v })}
-                  options={resolvedVideoOptions.modelOptions.map((item) => ({
-                    value: item.pipeline,
-                    label: item.spec.display_name,
-                  }))}
+                  options={[
+                    ...resolvedVideoOptions.modelOptions.map((item) => ({
+                      value: item.pipeline,
+                      label: item.spec.display_name,
+                    })),
+                    ...(
+                      isLocalMode && !resolvedVideoOptions.modelOptions.some((item) => item.pipeline === 'pro')
+                        ? [{
+                            value: 'pro',
+                            label: 'LTX-2.3 Pro (API)',
+                            disabled: true,
+                            tooltip: 'Enable LTX API models in Settings → General',
+                          }]
+                        : []
+                    ),
+                  ]}
                   trigger={
                     <>
                       <LightricksIcon className="h-3.5 w-3.5" />


### PR DESCRIPTION
## Summary

- keep `LTX-2.3 Pro (API)` visible in the model menu while local generation is selected
- disable that entry with guidance to enable LTX API models in Settings
- rename and clarify the Settings control so users know that API mode unlocks Fast and Pro, while local generation supports Fast only

## Why

The local backend intentionally exposes only the distilled Fast pipeline; Pro is available through the LTX API. In local mode, the frontend built the model menu exclusively from local model specs, so Pro disappeared without explaining whether it was missing, unsupported, or gated by another setting. That ambiguity led users to download the full dev checkpoint even though it is not wired into the local generation path.

This change makes the support boundary visible and gives users the exact next action. It does not automatically opt anyone into API generation or incur API usage.

This addresses the discoverability problem reported in #105. The local Pro support boundary was previously confirmed in #75.

## Validation

- `pnpm typecheck`
- `pnpm build:frontend`
- `pnpm backend:test` — 567 passed
